### PR TITLE
Correct gemini embedding model name

### DIFF
--- a/xenia/backend/app/services/embeddings.py
+++ b/xenia/backend/app/services/embeddings.py
@@ -38,7 +38,13 @@ def _embed_gemini(texts: List[str], model: Optional[str]) -> Optional[List[List[
     if not api_key:
         return None
     genai.configure(api_key=api_key)
-    model_name = model or os.getenv("EMBEDDING_MODEL", "text-embedding-004")
+    # Gemini embeddings require model names prefixed with 'models/' or 'tunedModels/'.
+    # Accept both forms and normalize here for robustness.
+    raw_model_name = model or os.getenv("EMBEDDING_MODEL", "models/text-embedding-004")
+    if not (raw_model_name.startswith("models/") or raw_model_name.startswith("tunedModels/")):
+        model_name = f"models/{raw_model_name}"
+    else:
+        model_name = raw_model_name
     vectors: List[List[float]] = []
     for t in texts:
         res = genai.embed_content(model=model_name, content=t[:8000])  # type: ignore


### PR DESCRIPTION
Normalize Gemini embedding model names to include the 'models/' prefix to resolve `ValueError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-735c3a65-978b-49ed-9edf-c03f4ebd4367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-735c3a65-978b-49ed-9edf-c03f4ebd4367">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

